### PR TITLE
Drop special case import for python 2 of collections.abc

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -6,12 +6,7 @@ import sys
 import threading
 
 from collections import OrderedDict
-
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-
+from collections.abc import Iterable, Mapping
 from itertools import count, repeat
 from time import sleep, time
 

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -5,7 +5,8 @@ import random
 import sys
 import threading
 
-from collections import Iterable, Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
 from itertools import count, repeat
 from time import sleep, time
 

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -6,7 +6,12 @@ import sys
 import threading
 
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+
 from itertools import count, repeat
 from time import sleep, time
 

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -1,11 +1,7 @@
 """URL Utilities."""
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
+from collections.abc import Mapping
 from functools import partial
 
 try:

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -1,7 +1,7 @@
 """URL Utilities."""
 from __future__ import absolute_import, unicode_literals
 
-from collections import Mapping
+from collections.abc import Mapping
 from functools import partial
 
 try:

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -1,7 +1,11 @@
 """URL Utilities."""
 from __future__ import absolute_import, unicode_literals
 
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 from functools import partial
 
 try:

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -9,12 +9,7 @@ import time
 import uuid
 
 from collections import OrderedDict
-
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable
-
+from collections.abc import Callable
 from itertools import count
 
 from case import Mock, call, patch, skip

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -9,7 +9,12 @@ import time
 import uuid
 
 from collections import OrderedDict
-from collections.abc import Callable
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 from itertools import count
 
 from case import Mock, call, patch, skip

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -8,7 +8,8 @@ import sys
 import time
 import uuid
 
-from collections import Callable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Callable
 from itertools import count
 
 from case import Mock, call, patch, skip


### PR DESCRIPTION
I saw you're working on dropping python2  support. When https://github.com/celery/kombu/pull/992 gets merged, it introduces some new code that should be dropped alongside python2 support